### PR TITLE
Added decoder `InputOffset` method

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -17,6 +17,9 @@ type Decoder interface {
 	// and then only read/touch the fields relevant for that kind.
 	NextToken(t *Token) error
 
+	// InputOffset returns the current offset in the input stream.
+	InputOffset() int
+
 	// Reset resets the Decoder to the given io.Reader.
 	Reset(r io.Reader)
 }
@@ -99,6 +102,10 @@ func (thiz *decoder) discard(n int) (int, error) {
 	}
 	thiz.r += n
 	return n, nil
+}
+
+func (thiz *decoder) InputOffset() int {
+	return thiz.r
 }
 
 func (thiz *decoder) Reset(r io.Reader) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -178,6 +178,29 @@ func TestIgnoreComments(t *testing.T) {
 	assert.Equal(t, io.EOF, err3)
 }
 
+func TestInputOffset(t *testing.T) {
+	// given
+	var tk gosaxml.Token
+
+	doc := "<a>Testing input offset</a>"
+	lastOffset := len(doc)
+
+	dec := gosaxml.NewDecoder(bufio.NewReaderSize(strings.NewReader(doc), 1024))
+
+	// when
+	_ = dec.NextToken(&tk)
+	off1 := dec.InputOffset()
+	_ = dec.NextToken(&tk)
+	off2 := dec.InputOffset()
+	_ = dec.NextToken(&tk)
+	off3 := dec.InputOffset()
+
+	// then
+	assert.Equal(t, 2, off1)
+	assert.Equal(t, 23, off2)
+	assert.Equal(t, lastOffset, off3)
+}
+
 func assertTextElement(t *testing.T, text string, token gosaxml.Token) {
 	assert.Equal(t, uint8(gosaxml.TokenTypeTextElement), token.Kind)
 	assert.Equal(t, []byte(text), token.ByteData)


### PR DESCRIPTION
This new method gives the location in the input stream of the most recently read byte.

Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>