### PR TITLE
Implement CDATA sections in decoder and encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ go get -u github.com/HBTGmbH/gosaxml
 * zero-allocation stream decoding of XML inputs (from `io.Reader`)
 * zero-allocation stream encoding of XML elements (to `io.Writer`)
 * tidying of XML namespace declarations of the encoder input
+* CDATA sections are decoded as `TokenTypeCharData` and encoded back as CDATA
 
 # Limitations
 
-* CDATA sections are not yet implemented (decoding returns an error)
 * `<!DOCTYPE>` declarations are not supported (decoding returns an error)
 * entity references (like `&amp;`) are not decoded/encoded but passed through verbatim (round-trip-safe)
 * element nesting depth is limited to 255

--- a/correctness_test.go
+++ b/correctness_test.go
@@ -31,6 +31,8 @@ func collectTokens(t *testing.T, input string) ([]string, error) {
 			tokens = append(tokens, "end:"+string(tk.Name.Local))
 		case gosaxml.TokenTypeTextElement:
 			tokens = append(tokens, "text:"+string(tk.ByteData))
+		case gosaxml.TokenTypeCharData:
+			tokens = append(tokens, "chardata:"+string(tk.ByteData))
 		case gosaxml.TokenTypeProcInst:
 			tokens = append(tokens, "pi:"+string(tk.Name.Local))
 		}
@@ -211,4 +213,94 @@ func TestRetryAfterErrorDoesNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
 		_ = dec.NextToken(&tk)
 	})
+}
+
+func TestCDataSectionIsDecodedAsCharData(t *testing.T) {
+	tokens, err := collectTokens(t, "<a><![CDATA[x < y & z]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "chardata:x < y & z", "end:a"}, tokens)
+}
+
+func TestCDataSectionMayContainMarkup(t *testing.T) {
+	tokens, err := collectTokens(t, "<a><![CDATA[<b>not an element</b>]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "chardata:<b>not an element</b>", "end:a"}, tokens)
+}
+
+func TestCDataSectionMayContainTwoBrackets(t *testing.T) {
+	tokens, err := collectTokens(t, "<a><![CDATA[a]]b]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "chardata:a]]b", "end:a"}, tokens)
+}
+
+func TestCDataSectionMayEndWithABracket(t *testing.T) {
+	tokens, err := collectTokens(t, "<a><![CDATA[a]]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "chardata:a]", "end:a"}, tokens)
+}
+
+func TestEmptyCDataSection(t *testing.T) {
+	tokens, err := collectTokens(t, "<a><![CDATA[]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "chardata:", "end:a"}, tokens)
+}
+
+func TestCDataSectionKeepsWhitespaceOnlyContent(t *testing.T) {
+	tokens, err := collectTokens(t, "<a><![CDATA[   ]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "chardata:   ", "end:a"}, tokens)
+}
+
+func TestCDataSectionLargerThanTheReadBuffer(t *testing.T) {
+	content := strings.Repeat("abc]]", 10000)
+	tokens, err := collectTokens(t, "<a><![CDATA["+content+"]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "chardata:" + content, "end:a"}, tokens)
+}
+
+func TestUnterminatedCDataSectionIsAnError(t *testing.T) {
+	_, err := collectTokens(t, "<a><![CDATA[never closed</a>")
+	assert.EqualError(t, err, "invalid XML: unterminated CDATA section")
+}
+
+func TestSectionOtherThanCDataIsAnError(t *testing.T) {
+	_, err := collectTokens(t, "<a><![FOO[bar]]></a>")
+	assert.EqualError(t, err, "invalid XML: expected CDATA section")
+}
+
+func TestTextAroundACDataSection(t *testing.T) {
+	tokens, err := collectTokens(t, "<a>before<![CDATA[middle]]>after</a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "text:before", "chardata:middle", "text:after", "end:a"}, tokens)
+}
+
+func TestTwoCDataSectionsInARow(t *testing.T) {
+	tokens, err := collectTokens(t, "<a><![CDATA[one]]><![CDATA[two]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:a", "chardata:one", "chardata:two", "end:a"}, tokens)
+}
+
+func TestCDataSectionSurvivesARoundTrip(t *testing.T) {
+	out, err := roundTrip(t, "<a><![CDATA[x < y & z]]></a>")
+	assert.Nil(t, err)
+	assert.Equal(t, "<a><![CDATA[x < y & z]]></a>", out)
+}
+
+func TestEncodingCDataSplitsAnEmbeddedDelimiter(t *testing.T) {
+	// A CDATA section cannot contain "]]>". A token carrying one must be
+	// written as two sections, or the output is not well-formed.
+	var w bytes.Buffer
+	enc := gosaxml.NewEncoder(&w)
+	err := enc.EncodeToken(&gosaxml.Token{
+		Kind:     gosaxml.TokenTypeCharData,
+		ByteData: []byte("a]]>b"),
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, enc.Flush())
+	assert.Equal(t, "<![CDATA[a]]]]><![CDATA[>b]]>", w.String())
+
+	// and the result must decode back to the original text
+	tokens, err := collectTokens(t, "<r>"+w.String()+"</r>")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"start:r", "chardata:a]]", "chardata:>b", "end:r"}, tokens)
 }

--- a/decoder.go
+++ b/decoder.go
@@ -195,7 +195,7 @@ func (thiz *decoder) NextToken(t *Token) error {
 					}
 				case '[':
 					thiz.lastStartElement = false
-					return thiz.readCDATA()
+					return thiz.readCDATA(t)
 				default:
 					return errors.New("invalid XML: comment or CDATA expected")
 				}
@@ -386,13 +386,59 @@ func (thiz *decoder) decodeTextGeneric(t *Token) (bool, error) {
 	}
 }
 
-func (thiz *decoder) readCDATA() error {
-	// discard "CDATA["
-	_, err := thiz.discard(6)
+var (
+	errCDATAExpected     = errors.New("invalid XML: expected CDATA section")
+	errCDATAUnterminated = errors.New("invalid XML: unterminated CDATA section")
+	cdataPrefix          = []byte("CDATA[")
+)
+
+// readCDATA reads a CDATA section into t, without its "<![CDATA[" and "]]>"
+// delimiters. The caller has consumed "<![".
+func (thiz *decoder) readCDATA(t *Token) error {
+	for thiz.r+len(cdataPrefix) > thiz.w {
+		if err := thiz.read0(); err != nil {
+			return errCDATAExpected
+		}
+	}
+	if !bytes.Equal(thiz.rb[thiz.r:thiz.r+len(cdataPrefix)], cdataPrefix) {
+		return errCDATAExpected
+	}
+	_, err := thiz.discard(len(cdataPrefix))
 	if err != nil {
 		return err
 	}
-	return errors.New("NYI")
+	i := len(thiz.bb)
+	for {
+		j := thiz.r
+		// The section ends at the first ">" preceded by "]]". Because the
+		// delimiter can straddle a buffer boundary, look for it in the
+		// collected bytes rather than in the read buffer.
+		k := bytes.IndexByte(thiz.rb[j:thiz.w], '>')
+		if k < 0 {
+			thiz.bb = append(thiz.bb, thiz.rb[j:thiz.w]...)
+			thiz.discardBuffer()
+			err = thiz.read0()
+			if err != nil {
+				if err == io.EOF {
+					return errCDATAUnterminated
+				}
+				return err
+			}
+			continue
+		}
+		thiz.bb = append(thiz.bb, thiz.rb[j:j+k+1]...)
+		_, err = thiz.discard(k + 1)
+		if err != nil {
+			return err
+		}
+		n := len(thiz.bb)
+		if n-i >= len(cdataEnd) && bytes.Equal(thiz.bb[n-len(cdataEnd):], cdataEnd) {
+			thiz.bb = thiz.bb[:n-len(cdataEnd)]
+			t.Kind = TokenTypeCharData
+			t.ByteData = thiz.bb[i:]
+			return nil
+		}
+	}
 }
 
 func (thiz *decoder) readName() (Name, byte, error) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -307,3 +307,27 @@ func endElementWithPrefix(prefix, local string) gosaxml.Token {
 		},
 	}
 }
+
+func BenchmarkNextTokenCDATA(b *testing.B) {
+	// given
+	doc := "<a><![CDATA[" + strings.Repeat("some text with ] and ]] in it", 1000) + "]]></a>"
+	r := strings.NewReader(doc)
+	dec := gosaxml.NewDecoder(r)
+
+	b.SetBytes(int64(len(doc)))
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		r.Reset(doc)
+		dec.Reset(r)
+		var tk gosaxml.Token
+		for {
+			err := dec.NextToken(&tk)
+			if err == io.EOF {
+				break
+			}
+			assert.Nil(b, err)
+		}
+	}
+}

--- a/encoder.go
+++ b/encoder.go
@@ -1,6 +1,7 @@
 package gosaxml
 
 import (
+	"bytes"
 	"errors"
 	"io"
 )
@@ -144,6 +145,12 @@ func (thiz *Encoder) EncodeToken(t *Token) error {
 			return err
 		}
 		thiz.lastStartElement = false
+	case TokenTypeCharData:
+		err := thiz.encodeCharData(t)
+		if err != nil {
+			return err
+		}
+		thiz.lastStartElement = false
 	default:
 		thiz.lastStartElement = false
 		return errors.New("NYI")
@@ -283,6 +290,51 @@ func (thiz *Encoder) encodeTextElement(t *Token) error {
 		return err
 	}
 	return thiz.writeBytes(t.ByteData)
+}
+
+var (
+	cdataStart = []byte("<![CDATA[")
+	cdataEnd   = []byte("]]>")
+)
+
+// encodeCharData writes the token back as a CDATA section, so that a
+// document decoded and encoded again keeps its CDATA sections.
+func (thiz *Encoder) encodeCharData(t *Token) error {
+	err := thiz.endLastStartElement()
+	if err != nil {
+		return err
+	}
+	err = thiz.writeBytes(cdataStart)
+	if err != nil {
+		return err
+	}
+	// A CDATA section cannot contain "]]>". Split the data into as many
+	// sections as needed, keeping the text itself unchanged.
+	data := t.ByteData
+	for {
+		k := bytes.Index(data, cdataEnd)
+		if k < 0 {
+			break
+		}
+		err = thiz.writeBytes(data[:k+2])
+		if err != nil {
+			return err
+		}
+		err = thiz.writeBytes(cdataEnd)
+		if err != nil {
+			return err
+		}
+		err = thiz.writeBytes(cdataStart)
+		if err != nil {
+			return err
+		}
+		data = data[k+2:]
+	}
+	err = thiz.writeBytes(data)
+	if err != nil {
+		return err
+	}
+	return thiz.writeBytes(cdataEnd)
 }
 
 func (thiz *Encoder) endLastStartElement() error {

--- a/fuzzing_test.go
+++ b/fuzzing_test.go
@@ -66,7 +66,7 @@ func buildElement(i int, b *bytes.Buffer, r *rand.Rand, lastOpen bool) bool {
 			_, _ = b.WriteString(" ")
 			buildAttribute(b, r)
 		}
-		ended := buildElement(r.Intn(2), b, r, true)
+		ended := buildElement(r.Intn(3), b, r, true)
 		if !ended {
 			_, _ = b.WriteString("</")
 			_, _ = b.WriteString(name)
@@ -78,6 +78,15 @@ func buildElement(i int, b *bytes.Buffer, r *rand.Rand, lastOpen bool) bool {
 			_, _ = b.WriteString(">")
 		}
 		_, _ = b.WriteString(randText(r))
+		return false
+	case 2:
+		if lastOpen {
+			_, _ = b.WriteString(">")
+		}
+		// randText never yields ">", so the text can never contain "]]>"
+		_, _ = b.WriteString("<![CDATA[")
+		_, _ = b.WriteString(randText(r))
+		_, _ = b.WriteString("]]>")
 		return false
 	default:
 		_, _ = b.WriteString("/>")


### PR DESCRIPTION
Moin.

`readCDATA` returned `errors.New("NYI")`, so any document containing a CDATA
section could not be decoded at all. This implements them on both sides.

### Decoder

* A CDATA section is decoded into a `TokenTypeCharData` token whose `ByteData`
  holds the content without the `<![CDATA[` and `]]>` delimiters. The token
  kind already existed in `types.go` but was never produced.
* Content is taken verbatim: markup, `&`, and `]]` sequences that do not form
  the delimiter all survive unchanged. Whitespace-only sections are kept — the
  author wrote them deliberately, unlike the whitespace between elements.
* Two failures were silent before and now report what is wrong:
  * `<![FOO[…` skipped six bytes and carried on with whatever followed, which
    silently changed the data. It is now `invalid XML: expected CDATA section`.
  * An unterminated section surfaced as `io.EOF`, which a caller cannot tell
    from a regular end of document — the tokens read so far simply vanished.
    It is now `invalid XML: unterminated CDATA section`.

### Encoder

* `TokenTypeCharData` is written back as a CDATA section, so decode/encode
  round-trips keep the sections rather than turning them into text.
* If such a token carries an embedded `]]>` — possible when the caller builds
  the token itself, not from decoded input — the encoder splits it across two
  sections instead of emitting a broken document.

### Tests

* Twelve cases in `correctness_test.go`: markup inside a section, `]]` in the
  content, a section ending in `]`, an empty one, whitespace-only, one larger
  than the read buffer (so the delimiter straddles a boundary), text before
  and after, two sections in a row, both error paths, and the round-trip.
* `fuzzing_test.go` now also generates CDATA sections, so all 100,000 random
  documents are checked for byte-identical round-trips. Verified that this
  test fails on `main` and passes here — the generator's `r.Intn(2)` became
  `r.Intn(3)` to reach the new case.
* Checked against a real-world invoice containing CDATA (a ZUGFeRD document,
  19 KB, 249 element and text values): the values are identical to what
  `encoding/xml` yields.

### Performance

The hot path is untouched — `BenchmarkNextToken` 99.95 → 100.2 ns/op and
`BenchmarkEncode` 39.75 → 40.52 ns/op (Apple M4, noise).

`BenchmarkNextTokenCDATA` was added for the new path. The section is scanned
with `bytes.IndexByte` and appended in slices rather than byte by byte, which
is what the surrounding code does; a byte-wise first draft measured 72× slower
on the same input.

`gofmt`, `go vet`, `revive` with the repo config, and the cross-builds from
the CI matrix all pass locally.

### One question

I kept whitespace-only CDATA sections even where `xml:space` is not
`preserve`, on the grounds that a section is explicit markup rather than
incidental formatting. If you would rather have them dropped like ordinary
whitespace text, that is a two-line change and I am happy to make it.
